### PR TITLE
Match sensitivity mouse and joystick

### DIFF
--- a/src/ActionGameCore/Assets/FPSCameraControls/CHANGELOG.md
+++ b/src/ActionGameCore/Assets/FPSCameraControls/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
+## [1.2.0] - 2024-05-16
+### Changed
+- Match camera sensitivity of mouse and controller.
+  - Rename and add serialized field for input action reference.
+  - Change default sensitivity to 1.0
+  - Change calculation of camera angle.
 
 ## [1.1.0] - 2024-03-06
-### Fixed
+### Changed
 - Change parameter type of input to InputActionReference.
 
 ## [1.0.1] - 2024-03-04
-### Fixed
+### Changed
 - Show input action name to inspector.
 
 ## [1.0.0] - 2024-02-27

--- a/src/ActionGameCore/Assets/FPSCameraControls/Scripts/Runtime/FPSCameraController.cs.meta
+++ b/src/ActionGameCore/Assets/FPSCameraControls/Scripts/Runtime/FPSCameraController.cs.meta
@@ -4,7 +4,8 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences:
-  - _lookActionReference: {fileID: -5630151704836100654, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  - _deltaActionReference: {fileID: -5630151704836100654, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  - _continuousActionreference: {instanceID: 0}
   - Target: {instanceID: 0}
   executionOrder: 0
   icon: {instanceID: 0}

--- a/src/ActionGameCore/Assets/FPSCameraControls/package.json
+++ b/src/ActionGameCore/Assets/FPSCameraControls/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.eviltwo.fps-camera-controls",
     "displayName": "FPS Camera Controls",
-    "version": "1.1.0",             
+    "version": "1.2.0",             
     "unity": "2022.3",
     "description": "Camera movements for FPS.",
     "author": {

--- a/src/ActionGameCore/Assets/Samples/Data/SampleInputActions.inputactions
+++ b/src/ActionGameCore/Assets/Samples/Data/SampleInputActions.inputactions
@@ -15,9 +15,18 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "Look",
+                    "name": "LookDelta",
                     "type": "Value",
                     "id": "6b444451-8a00-4d00-a97e-f47457f736a8",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "LookContinuous",
+                    "type": "Value",
+                    "id": "2827cdac-37f5-47cf-bd0d-2923826c6866",
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
@@ -177,23 +186,12 @@
                 },
                 {
                     "name": "",
-                    "id": "c1f7a91b-d0fd-4a62-997e-7fb9b69bf235",
-                    "path": "<Gamepad>/rightStick",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Gamepad",
-                    "action": "Look",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "8c8e490b-c610-4785-884f-f04217b23ca4",
                     "path": "<Pointer>/delta",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Keyboard&Mouse;Touch",
-                    "action": "Look",
+                    "action": "LookDelta",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -204,7 +202,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "Joystick",
-                    "action": "Look",
+                    "action": "LookDelta",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -249,6 +247,17 @@
                     "processors": "",
                     "groups": "Keyboard&Mouse",
                     "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c1f7a91b-d0fd-4a62-997e-7fb9b69bf235",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "LookContinuous",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/src/ActionGameCore/Assets/Samples/Scenes/SampleScene.unity
+++ b/src/ActionGameCore/Assets/Samples/Scenes/SampleScene.unity
@@ -1367,6 +1367,7 @@ MonoBehaviour:
   Sensitivity: 1
   AngleMin: -90
   AngleMax: 90
+  SmoothingFrameCount: 2
   _lockAndHideCursor: 1
 --- !u!114 &963194230
 MonoBehaviour:
@@ -1393,6 +1394,7 @@ MonoBehaviour:
   WallLayerMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  SmoothingFrameCount: 2
   _lockAndHideCursor: 1
 --- !u!1 &970461546
 GameObject:
@@ -1682,6 +1684,82 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1163315763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1163315764}
+  - component: {fileID: 1163315766}
+  - component: {fileID: 1163315765}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1163315764
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1163315763}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1318817724}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1163315765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1163315763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1163315766
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1163315763}
+  m_CullTransparentMesh: 1
 --- !u!1 &1287469865
 GameObject:
   m_ObjectHideFlags: 0
@@ -2049,6 +2127,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1163315764}
   - {fileID: 209071632}
   m_Father: {fileID: 0}
   m_RootOrder: 20

--- a/src/ActionGameCore/Assets/Samples/Scenes/SampleScene.unity
+++ b/src/ActionGameCore/Assets/Samples/Scenes/SampleScene.unity
@@ -1380,12 +1380,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 555f5af3ecd5c7a47862ada8aded246a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _lookActionReference: {fileID: -5630151704836100654, guid: d050cea4568e2be47bc9a4f2c136ccf9, type: 3}
+  _deltaActionReference: {fileID: -5630151704836100654, guid: d050cea4568e2be47bc9a4f2c136ccf9, type: 3}
+  _continuousActionreference: {fileID: 4073854690803581126, guid: d050cea4568e2be47bc9a4f2c136ccf9, type: 3}
   Target: {fileID: 177208273}
   Offset: {x: 0, y: 1.5, z: 0}
   OffsetRotation: 1
   Distance: 3
-  Sensitivity: 0.1
+  Sensitivity: 1
   AngleMin: -90
   AngleMax: 90
   IsCheckWall: 0

--- a/src/ActionGameCore/Assets/Samples/Scenes/SampleScene.unity
+++ b/src/ActionGameCore/Assets/Samples/Scenes/SampleScene.unity
@@ -1360,10 +1360,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 76bea717eafe0f14188a4b53c3696b73, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _lookActionReference: {fileID: -5630151704836100654, guid: d050cea4568e2be47bc9a4f2c136ccf9, type: 3}
+  _deltaActionReference: {fileID: -5630151704836100654, guid: d050cea4568e2be47bc9a4f2c136ccf9, type: 3}
+  _continuousActionreference: {fileID: 4073854690803581126, guid: d050cea4568e2be47bc9a4f2c136ccf9, type: 3}
   Target: {fileID: 177208273}
   OffsetY: 1.5
-  Sensitivity: 0.1
+  Sensitivity: 1
   AngleMin: -90
   AngleMax: 90
   _lockAndHideCursor: 1

--- a/src/ActionGameCore/Assets/TPSCameraControls/CHANGELOG.md
+++ b/src/ActionGameCore/Assets/TPSCameraControls/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [1.2.0] - 2024-05-16
+### Changed
+- Match camera sensitivity of mouse and controller.
+  - Rename and add serialized field for input action reference.
+  - Change default sensitivity to 1.0
+  - Change calculation of camera angle.
 
 ## [1.1.0] - 2024-03-06
 ### Fixed

--- a/src/ActionGameCore/Assets/TPSCameraControls/Scripts/Runtime/TPSCameraController.cs
+++ b/src/ActionGameCore/Assets/TPSCameraControls/Scripts/Runtime/TPSCameraController.cs
@@ -1,4 +1,5 @@
 #if SUPPORT_INPUTSYSTEM
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -13,7 +14,10 @@ namespace FPSCameraControls
         }
 
         [SerializeField]
-        private InputActionReference _lookActionReference = null;
+        private InputActionReference _deltaActionReference = null;
+
+        [SerializeField]
+        private InputActionReference _continuousActionreference = null;
 
         [SerializeField]
         public Transform Target = null;
@@ -28,7 +32,7 @@ namespace FPSCameraControls
         public float Distance = 5.0f;
 
         [SerializeField]
-        public float Sensitivity = 0.1f;
+        public float Sensitivity = 1.0f;
 
         [SerializeField]
         public float AngleMin = -90.0f;
@@ -43,13 +47,19 @@ namespace FPSCameraControls
         public LayerMask WallLayerMask = ~0;
 
         [SerializeField]
+        public int SmoothingFrameCount = 2;
+
+        [SerializeField]
         private bool _lockAndHideCursor = true;
 
         private Vector3 _lookAngles;
+        private List<Vector2> _deltaPositions = new List<Vector2>();
+        private List<float> _deltaTimes = new List<float>();
 
         private void Start()
         {
-            _lookActionReference?.action.Enable();
+            _deltaActionReference?.action.Enable();
+            _continuousActionreference?.action.Enable();
             if (_lockAndHideCursor)
             {
                 Cursor.visible = false;
@@ -64,14 +74,42 @@ namespace FPSCameraControls
                 return;
             }
 
-            var rotation = Target.rotation;
-            if (_lookActionReference != null)
+            var deltaAngle = Vector2.zero;
+            if (_deltaActionReference != null)
             {
-                var look = _lookActionReference.action.ReadValue<Vector2>();
-                _lookAngles.x = Mathf.Clamp(_lookAngles.x - look.y * Sensitivity, -AngleMax, -AngleMin); // Look up and down
-                _lookAngles.y = (_lookAngles.y + look.x * Sensitivity) % 360; // Look left and right
-                rotation = Quaternion.Euler(_lookAngles);
+                _deltaPositions.Add(_deltaActionReference.action.ReadValue<Vector2>());
+                _deltaTimes.Add(Time.deltaTime);
+                SmoothingFrameCount = Mathf.Max(1, SmoothingFrameCount);
+                if (_deltaPositions.Count > SmoothingFrameCount)
+                {
+                    _deltaPositions.RemoveRange(0, _deltaPositions.Count - SmoothingFrameCount);
+                    _deltaTimes.RemoveRange(0, _deltaTimes.Count - SmoothingFrameCount);
+                }
+                var totalPosition = Vector2.zero;
+                var totalTime = 0f;
+                for (int i = 0; i < _deltaPositions.Count; i++)
+                {
+                    totalPosition += _deltaPositions[i];
+                    totalTime += _deltaTimes[i];
+                }
+                var deltaPositionAverage = totalPosition / totalTime;
+                var smoothDeltaPosition = deltaPositionAverage * Time.deltaTime;
+
+                const float DpiAverage = 96;
+                var dpi = Screen.dpi == 0 ? DpiAverage : Screen.dpi;
+                const float InchForTurn = 13;
+                deltaAngle += smoothDeltaPosition / dpi / InchForTurn * 180;
             }
+
+            if (_continuousActionreference != null)
+            {
+                const float SecondsForTurn = 1.0f;
+                deltaAngle += _continuousActionreference.action.ReadValue<Vector2>() * Time.deltaTime / SecondsForTurn * 180;
+            }
+
+            _lookAngles.x = Mathf.Clamp(_lookAngles.x - deltaAngle.y * Sensitivity, -AngleMax, -AngleMin); // Look up and down
+            _lookAngles.y = (_lookAngles.y + deltaAngle.x * Sensitivity) % 360; // Look left and right
+            var rotation = Quaternion.Euler(_lookAngles);
 
             var offsetRotation = OffsetRotation == OffsetRotationType.FullRotation ? rotation : Quaternion.AngleAxis(_lookAngles.y, Vector3.up);
             var pivot = Target.position + offsetRotation * Offset;

--- a/src/ActionGameCore/Assets/TPSCameraControls/Scripts/Runtime/TPSCameraController.cs.meta
+++ b/src/ActionGameCore/Assets/TPSCameraControls/Scripts/Runtime/TPSCameraController.cs.meta
@@ -4,7 +4,8 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences:
-  - _lookActionReference: {fileID: -5630151704836100654, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  - _deltaActionReference: {fileID: -5630151704836100654, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  - _continuousActionreference: {instanceID: 0}
   - Target: {instanceID: 0}
   executionOrder: 0
   icon: {instanceID: 0}

--- a/src/ActionGameCore/Assets/TPSCameraControls/package.json
+++ b/src/ActionGameCore/Assets/TPSCameraControls/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.eviltwo.tps-camera-controls",
     "displayName": "TPS Camera Controls",
-    "version": "1.1.0",             
+    "version": "1.2.0",             
     "unity": "2022.3",
     "description": "Camera movements for TPS.",
     "author": {


### PR DESCRIPTION
- Match camera sensitivity of mouse and controller.
  - Rename and add serialized field for input action reference.
  - Change default sensitivity to 1.0
  - Change calculation of camera angle.

マウス(delta pixels)とJoystick(0.0~1.0の傾き)は値の大きさと性質が異なるため、処理を変更しました。
- マウスを現実の13インチ移動したら180度回転するようにし、これをSensitivity=1としました。
- Joystickを1秒傾け続けたら180度回転するようにし、これをSensitivity=1としました。
- Windows10設定のカーソル速度を10(デフォルト)にすればいい具合になります。
- マウスのdeltaがpixel単位で不安定なため、スムージング処理を導入しました。ただし、値を大きくしすぎると酔いやすくなります。